### PR TITLE
filter out empty headers

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -2004,7 +2004,7 @@ class S3
 
 		// CanonicalHeaders
 		foreach ($headers as $k => $v)
-			$combinedHeaders[strtolower($k)] = trim($v);
+			if (!empty($v)) $combinedHeaders[strtolower($k)] = trim($v);
 		foreach ($amzHeaders as $k => $v) 
 			$combinedHeaders[strtolower($k)] = trim($v);
 		uksort($combinedHeaders, array('self', '__sortMetaHeadersCmp'));


### PR DESCRIPTION
Fixes issues #157 & #171.

It turns out that ListBuckets does not work on non-amazon services due to a 403 SignatureDoesNotMatch error caused by the empty headers.